### PR TITLE
fix: copy macOS DMG to root workspace for artifact upload

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -229,6 +229,7 @@ jobs:
           # DMG
           chmod +x scripts/build_dmg.sh
           ./scripts/build_dmg.sh
+          cp -f build/macos/Build/Products/Release/T2DECODE-macOS.dmg T2DECODE-macOS.dmg
 
           # PKG (unsigned by default)
           chmod +x scripts/build_pkg.sh


### PR DESCRIPTION
Ensures the build_release.yml copies T2DECODE-macOS.dmg to the root workspace so that it gets uploaded as a release asset.