### PR TITLE
fix(setup): recreate build symlink target folder automatically

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,7 +39,13 @@ if [ ! -f "assets/logo.png" ]; then
 fi
 
 # Create necessary directories
-mkdir -p build
+if [ -L "build" ]; then
+    TARGET=$(readlink "build")
+    echo "ℹ️ 'build' is a symlink pointing to $TARGET. Recreating target directory..."
+    mkdir -p "$TARGET"
+else
+    mkdir -p build
+fi
 mkdir -p assets/icons
 mkdir -p assets/splash
 


### PR DESCRIPTION
Ensures that if the build folder is a symlink (e.g., to /tmp/t2decode-build), the script automatically creates its target folder instead of failing.