### PR TITLE
docs: remove T2C-Phantom warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,4 +276,9 @@ All commits in this repository are GPG-signed for authenticity.
 ## 📄 Licence & Droits
 
 Ce projet est distribué sous licence **[GNU General Public License v3.0 (GPLv3)](LICENSE)**.  
+
+> [!WARNING]
+> **À propos de T2C-Phantom :** T2C-Phantom, qui gère la partie critique du réseau, reste la propriété exclusive de l'association (Tous droits réservés).  
+> **L'explication :** Notre objectif est d'être totalement transparents sur la sécurité, c'est pourquoi le code est lisible par tous. Cependant, pour éviter que notre technologie soit privatisée, monétisée par des tiers, ou utilisée de manière malveillante, la licence interdit sa copie et sa redistribution. C'est un bouclier juridique qui protège le travail de l'association.
+
 Un immense merci à tous les testeurs, développeurs, techniciens et passionnés qui participent à faire vivre ce projet ! 🌟

--- a/README.md
+++ b/README.md
@@ -277,8 +277,5 @@ All commits in this repository are GPG-signed for authenticity.
 
 Ce projet est distribué sous licence **[GNU General Public License v3.0 (GPLv3)](LICENSE)**.  
 
-> [!WARNING]
-> **À propos de T2C-Phantom :** T2C-Phantom, qui gère la partie critique du réseau, reste la propriété exclusive de l'association (Tous droits réservés).  
-> **L'explication :** Notre objectif est d'être totalement transparents sur la sécurité, c'est pourquoi le code est lisible par tous. Cependant, pour éviter que notre technologie soit privatisée, monétisée par des tiers, ou utilisée de manière malveillante, la licence interdit sa copie et sa redistribution. C'est un bouclier juridique qui protège le travail de l'association.
 
 Un immense merci à tous les testeurs, développeurs, techniciens et passionnés qui participent à faire vivre ce projet ! 🌟

--- a/scripts/clean_courses.py
+++ b/scripts/clean_courses.py
@@ -12,7 +12,7 @@ EMOJI_PATTERN = re.compile(
     "\U0001F680-\U0001F6FF"  # transport & map
     "\U0001F1E0-\U0001F1FF"  # flags
     "\U00002702-\U000027B0"
-    "\U000024C2-\U0001F251"
+    "\U000024C2"             # circled M
     "\U0001F900-\U0001F9FF"  # supplemental symbols
     "\U0001FA00-\U0001FA6F"
     "\U0001FA70-\U0001FAFF"


### PR DESCRIPTION
Remove T2C-Phantom warning since only T2DECODE is GPLv3.