### PR TITLE
chore: add SPDX license identifiers to source files

### DIFF
--- a/test/unit/ai_tutor_provider_test.dart
+++ b/test/unit/ai_tutor_provider_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tutodecode/features/ghost_ai/providers/ai_tutor_provider.dart';

--- a/test/unit/course_expansion_test.dart
+++ b/test/unit/course_expansion_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:tutodecode/utils/course_expansion.dart';

--- a/test/unit/extra_coverage_test.dart
+++ b/test/unit/extra_coverage_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tutodecode/core/services/ai_service.dart';
 import 'package:tutodecode/core/services/terminal_service.dart';

--- a/test/unit/gamification_models_test.dart
+++ b/test/unit/gamification_models_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tutodecode/features/courses/models/gamification_models.dart';

--- a/test/unit/search_provider_test.dart
+++ b/test/unit/search_provider_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tutodecode/core/providers/search_provider.dart';
 

--- a/test/unit/security_methods_test.dart
+++ b/test/unit/security_methods_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 import 'package:tutodecode/core/security/anti_tampering.dart';

--- a/test/unit/security_test.dart
+++ b/test/unit/security_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tutodecode/core/security/anti_tampering.dart';
 import 'package:tutodecode/core/security/build_verification.dart';

--- a/test/unit/storage_service_test.dart
+++ b/test/unit/storage_service_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/services.dart';

--- a/test/widget/app_shell_test.dart
+++ b/test/widget/app_shell_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';

--- a/test/widget/network_simulator_test.dart
+++ b/test/widget/network_simulator_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tutodecode/features/lab/simulators/network_simulator.dart';

--- a/test/widget/theme_modes_golden_test.dart
+++ b/test/widget/theme_modes_golden_test.dart
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import 'dart:io';
 
 import 'package:flutter/material.dart';


### PR DESCRIPTION
This PR adds the `SPDX-License-Identifier: GPL-3.0-or-later` header to all Dart source files to improve the OpenSSF Scorecard license score.