### PR TITLE
ci: auto-tag workflow and README cleanup

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'LICENSE.txt'
+      - 'DCO.md'
+      - '.gitignore'
+      - '.claudeignore'
+      - '.ci-trigger'
 
 permissions:
   contents: write

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -62,6 +62,16 @@ jobs:
           TAG="${{ steps.next_tag.outputs.NEXT_TAG }}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          # 1. Update README.md version references
+          sed -i -E "s/v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?/$TAG/g" README.md
+          
+          # 2. Commit and push README.md update to main
+          git add README.md
+          git commit -m "docs: update README release version to $TAG [skip ci]"
+          git push origin main
+          
+          # 3. Create and push tag
           git tag -a "$TAG" -m "Automated release tag $TAG"
           git push origin "$TAG"
 

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -65,15 +65,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           
-          # 1. Update README.md version references (except for macOS App Store line)
-          sed -i -E '/macOS|App Store/! s/v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?/'"$TAG"'/g' README.md
-          
-          # 2. Commit and push README.md update to main
-          git add README.md
-          git commit -m "docs: update README release version to $TAG [skip ci]"
-          git push origin main
-          
-          # 3. Create and push tag
           git tag -a "$TAG" -m "Automated release tag $TAG"
           git push origin "$TAG"
 

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -1,0 +1,67 @@
+name: Auto Tag and Trigger Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history and tags
+
+      - name: Determine Next Tag
+        id: next_tag
+        shell: bash
+        run: |
+          # 1. Read version from pubspec.yaml
+          VERSION_LINE=$(grep '^version:' pubspec.yaml)
+          BASE_VERSION=$(echo "$VERSION_LINE" | cut -d' ' -f2 | cut -d'+' -f1)
+          echo "Base version: $BASE_VERSION"
+
+          # 2. Get matching tags starting with the base version (e.g., v1.0.2)
+          MATCHING_TAGS=$(git tag -l "v$BASE_VERSION*")
+
+          if [ -z "$MATCHING_TAGS" ]; then
+            NEXT_TAG="v$BASE_VERSION.1"
+          else
+            LATEST_SUFFIX=$(echo "$MATCHING_TAGS" | grep -E "^v$BASE_VERSION\.[0-9]+$" | sed "s/^v$BASE_VERSION\.//" | sort -n | tail -n1)
+            if [ -z "$LATEST_SUFFIX" ]; then
+              NEXT_TAG="v$BASE_VERSION.1"
+            else
+              NEXT_SUFFIX=$((LATEST_SUFFIX + 1))
+              NEXT_TAG="v$BASE_VERSION.$NEXT_SUFFIX"
+            fi
+          fi
+
+          echo "NEXT_TAG=$NEXT_TAG" >> $GITHUB_OUTPUT
+          echo "Determined next tag: $NEXT_TAG"
+
+      - name: Create and Push Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="${{ steps.next_tag.outputs.NEXT_TAG }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Automated release tag $TAG"
+          git push origin "$TAG"
+
+      - name: Trigger Release Workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="${{ steps.next_tag.outputs.NEXT_TAG }}"
+          # Attente courte pour que GitHub enregistre le tag poussé
+          sleep 5
+          gh workflow run build_release.yml --ref "refs/tags/$TAG" -f target_tag="$TAG"

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -63,8 +63,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           
-          # 1. Update README.md version references
-          sed -i -E "s/v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?/$TAG/g" README.md
+          # 1. Update README.md version references (except for macOS App Store line)
+          sed -i -E '/macOS|App Store/! s/v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?/'"$TAG"'/g' README.md
           
           # 2. Commit and push README.md update to main
           git add README.md

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -15,15 +15,17 @@ on:
       - '.ci-trigger'
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 jobs:
   auto-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0 # Fetch all history and tags
 

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -78,6 +78,7 @@ jobs:
 
     steps:
       - name: Harden Runner
+        if: runner.os != 'macOS'
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit

--- a/README.md
+++ b/README.md
@@ -188,16 +188,16 @@ T2DECODE (Application Flutter)
 
 <img src="assets/separator.svg" width="100%" height="4">
 
-## 📥 Téléchargements & Plateformes (v1.0.2.1)
+## 📥 Téléchargements & Plateformes
 
 ➡️ [**Télécharger les binaires précompilés (Releases GitHub)**](https://github.com/TUTODECODE-FR/T2DECODE/releases/latest)
 
 | Plateforme | Format de Distribution | Statut CI | Accessibilité |
 | :--- | :--- | :---: | :---: |
-| ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white) | **APK** / AAB (64-bit) | Actif | Disponible (v1.0.2.1) |
-| ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) | **ZIP** / Installateur EXE | Actif | Disponible (v1.0.2.1) |
-| ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white) | **[App Store](https://apps.apple.com/us/app/t2decode-plateforme/id6762523276?mt=12)** / PKG / ZIP Universel | Actif | Disponible (v1.0.2) |
-| ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) | **AppImage** / DEB (64-bit) | Actif | Disponible (v1.0.2.1) |
+| ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white) | **APK** / AAB (64-bit) | Actif | Disponible |
+| ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) | **ZIP** / Installateur EXE | Actif | Disponible |
+| ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white) | **[App Store](https://apps.apple.com/us/app/t2decode-plateforme/id6762523276?mt=12)** / PKG / ZIP Universel | Actif | Disponible |
+| ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) | **AppImage** / DEB (64-bit) | Actif | Disponible |
 
 > 🔒 **Garantie d'intégrité** : Chaque version s'accompagne d'un fichier `SHA256SUMS.txt` et de signatures cryptographiques pour authentifier la provenance des binaires.
 

--- a/README.md
+++ b/README.md
@@ -188,16 +188,16 @@ T2DECODE (Application Flutter)
 
 <img src="assets/separator.svg" width="100%" height="4">
 
-## 📥 Téléchargements & Plateformes (v1.0.2)
+## 📥 Téléchargements & Plateformes (v1.0.2.1)
 
 ➡️ [**Télécharger les binaires précompilés (Releases GitHub)**](https://github.com/TUTODECODE-FR/T2DECODE/releases/latest)
 
 | Plateforme | Format de Distribution | Statut CI | Accessibilité |
 | :--- | :--- | :---: | :---: |
-| ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white) | **APK** / AAB (64-bit) | Actif | Disponible (v1.0.2) |
-| ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) | **ZIP** / Installateur EXE | Actif | Disponible (v1.0.2) |
-| ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white) | **[App Store](https://apps.apple.com/us/app/t2decode-plateforme/id6762523276?mt=12)** / PKG / ZIP Universel | Actif | Disponible (v1.0.2) |
-| ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) | **AppImage** / DEB (64-bit) | Actif | Disponible (v1.0.2) |
+| ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white) | **APK** / AAB (64-bit) | Actif | Disponible (v1.0.2.1) |
+| ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) | **ZIP** / Installateur EXE | Actif | Disponible (v1.0.2.1) |
+| ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white) | **[App Store](https://apps.apple.com/us/app/t2decode-plateforme/id6762523276?mt=12)** / PKG / ZIP Universel | Actif | Disponible (v1.0.2.1) |
+| ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) | **AppImage** / DEB (64-bit) | Actif | Disponible (v1.0.2.1) |
 
 > 🔒 **Garantie d'intégrité** : Chaque version s'accompagne d'un fichier `SHA256SUMS.txt` et de signatures cryptographiques pour authentifier la provenance des binaires.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ T2DECODE (Application Flutter)
 | :--- | :--- | :---: | :---: |
 | ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white) | **APK** / AAB (64-bit) | Actif | Disponible (v1.0.2.1) |
 | ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) | **ZIP** / Installateur EXE | Actif | Disponible (v1.0.2.1) |
-| ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white) | **[App Store](https://apps.apple.com/us/app/t2decode-plateforme/id6762523276?mt=12)** / PKG / ZIP Universel | Actif | Disponible (v1.0.2.1) |
+| ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white) | **[App Store](https://apps.apple.com/us/app/t2decode-plateforme/id6762523276?mt=12)** / PKG / ZIP Universel | Actif | Disponible (v1.0.2) |
 | ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) | **AppImage** / DEB (64-bit) | Actif | Disponible (v1.0.2.1) |
 
 > 🔒 **Garantie d'intégrité** : Chaque version s'accompagne d'un fichier `SHA256SUMS.txt` et de signatures cryptographiques pour authentifier la provenance des binaires.


### PR DESCRIPTION
## Résumé des changements

Ce PR inclut les améliorations CI et README faites après le merge du PR #97.

### Modifications

#### `.github/workflows/auto_tag.yml`
- **Suppression du push direct vers `main`** : Le workflow ne tente plus de modifier et pousser directement le README vers `main`, ce qui violait les règles de protection de la branche (PR obligatoire, status checks requis).
- Le tag est maintenant créé et poussé directement sans commit préalable sur `main`.

#### `README.md`
- **Suppression des numéros de version statiques** dans le tableau des téléchargements (ex. `Disponible (v1.0.2.1)` → `Disponible`) : évite les informations obsolètes entre deux releases.
- Les liens GitHub Releases pointent toujours vers la dernière release (`/releases/latest`).
- L'en-tête de section ne mentionne plus de version codée en dur.

### Contexte
L'ancienne approche tentait de pousser directement sur `main` depuis le workflow CI pour mettre à jour le README, ce qui échouait à cause des branch protection rules. La solution retenue est de ne plus modifier le README automatiquement depuis la CI — les versions dans le README seront mises à jour manuellement lors des PRs de release.

Signed-off-by: MAXIME MARTIN CIVET <108419734+itswinancher@users.noreply.github.com>