### PR TITLE
ci: remove automated README push and clean up version references

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -65,15 +65,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           
-          # 1. Update README.md version references (except for macOS App Store line)
-          sed -i -E '/macOS|App Store/! s/v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?/'"$TAG"'/g' README.md
-          
-          # 2. Commit and push README.md update to main
-          git add README.md
-          git commit -m "docs: update README release version to $TAG [skip ci]"
-          git push origin main
-          
-          # 3. Create and push tag
           git tag -a "$TAG" -m "Automated release tag $TAG"
           git push origin "$TAG"
 

--- a/README.md
+++ b/README.md
@@ -188,16 +188,16 @@ T2DECODE (Application Flutter)
 
 <img src="assets/separator.svg" width="100%" height="4">
 
-## 📥 Téléchargements & Plateformes (v1.0.2.1)
+## 📥 Téléchargements & Plateformes
 
 ➡️ [**Télécharger les binaires précompilés (Releases GitHub)**](https://github.com/TUTODECODE-FR/T2DECODE/releases/latest)
 
 | Plateforme | Format de Distribution | Statut CI | Accessibilité |
 | :--- | :--- | :---: | :---: |
-| ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white) | **APK** / AAB (64-bit) | Actif | Disponible (v1.0.2.1) |
-| ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) | **ZIP** / Installateur EXE | Actif | Disponible (v1.0.2.1) |
-| ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white) | **[App Store](https://apps.apple.com/us/app/t2decode-plateforme/id6762523276?mt=12)** / PKG / ZIP Universel | Actif | Disponible (v1.0.2) |
-| ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) | **AppImage** / DEB (64-bit) | Actif | Disponible (v1.0.2.1) |
+| ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white) | **APK** / AAB (64-bit) | Actif | Disponible |
+| ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white) | **ZIP** / Installateur EXE | Actif | Disponible |
+| ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white) | **[App Store](https://apps.apple.com/us/app/t2decode-plateforme/id6762523276?mt=12)** / PKG / ZIP Universel | Actif | Disponible |
+| ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black) | **AppImage** / DEB (64-bit) | Actif | Disponible |
 
 > 🔒 **Garantie d'intégrité** : Chaque version s'accompagne d'un fichier `SHA256SUMS.txt` et de signatures cryptographiques pour authentifier la provenance des binaires.
 


### PR DESCRIPTION
## Résumé

Corrections post-merge du PR #97 pour respecter les branch protection rules.

### Changements

#### `.github/workflows/auto_tag.yml`
- Suppression du push direct vers `main` pour mettre à jour le README (violait les branch protection rules : PR obligatoire + status checks requis)
- Le workflow crée et pousse uniquement le tag, puis déclenche le build release

#### `README.md`
- Suppression des numéros de version statiques dans le tableau des téléchargements
- Les versions seront désormais mises à jour manuellement dans chaque PR de release

Signed-off-by: MAXIME MARTIN CIVET <108419734+itswinancher@users.noreply.github.com>