### PR TITLE
fix: use pod install --no-repo-update for macOS and iOS CI builds

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -223,6 +223,11 @@ jobs:
         if: matrix.platform == 'macos'
         shell: bash
         run: |
+          # Tous les pods Flutter utilisent des specs locaux (Flutter ephemeral).
+          # On pré-installe avec --no-repo-update pour contourner le clonage de
+          # cdn.cocoapods.org qui échoue sur les runners GitHub Actions macOS.
+          cd macos && pod install --no-repo-update && cd ..
+
           flutter build macos --release
 
           APP_PATH="build/macos/Build/Products/Release/T2DECODE.app"
@@ -421,6 +426,9 @@ jobs:
 
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/Runner.mobileprovision"
+
+          # Pré-installer les pods sans accès CDN (specs locaux Flutter)
+          cd ios && pod install --no-repo-update && cd ..
 
           flutter build ipa --release --export-options-plist=ios/ExportOptions.plist
 


### PR DESCRIPTION
## Problème

`flutter build macos` / `flutter build ipa` lancent `pod install` en interne. CocoaPods tente alors de cloner `https://cdn.cocoapods.org/` pour initialiser le spec repo trunk — ce domaine ne résout pas DNS sur les runners GitHub Actions macOS.

## Cause racine

Tous les pods de ce projet (connectivity_plus, device_info_plus, etc.) utilisent des podspecs **locaux** fournis par le Flutter SDK (dossier `ephemeral`). Le CDN CocoaPods n'est **pas nécessaire**.

## Fix

Lancer `pod install --no-repo-update` **avant** `flutter build macos/ipa`. Flutter détecte que les pods sont déjà installés et saute son propre `pod install`.

```bash
cd macos && pod install --no-repo-update && cd ..
flutter build macos --release
```

Idem pour iOS :
```bash  
cd ios && pod install --no-repo-update && cd ..
flutter build ipa --release ...
```

Fixes: Build #20 et #21 — `Could not resolve host: cdn.cocoapods.org`

Signed-off-by: MAXIME MARTIN CIVET <108419734+itswinancher@users.noreply.github.com>