### PR TITLE
fix(ci): use valid name for CocoaPods specs repo setup

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -349,8 +349,7 @@ jobs:
         shell: bash
         run: |
           # Ensure CocoaPods uses the GitHub Specs repo (avoids CDN DNS issues)
-          pod repo remove trunk || true
-          pod repo add trunk https://github.com/CocoaPods/Specs.git --silent
+          pod repo add cocoapods https://github.com/CocoaPods/Specs.git --silent || true
 
       - name: Run tests
         run: flutter test --dart-define=SKIP_GOLDENS=true


### PR DESCRIPTION
Avoids using the reserved name 'trunk' in pod repo add, which was failing the macOS release build.