### PR TITLE
fix(ci): delete git tag on release build failure

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -349,8 +349,7 @@ jobs:
         shell: bash
         run: |
           # Ensure CocoaPods uses the GitHub Specs repo (avoids CDN DNS issues)
-          pod repo remove trunk || true
-          pod repo add trunk https://github.com/CocoaPods/Specs.git --silent
+          pod repo add cocoapods https://github.com/CocoaPods/Specs.git --silent || true
 
       - name: Run tests
         run: flutter test --dart-define=SKIP_GOLDENS=true

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -824,3 +824,19 @@ jobs:
 
           # Nettoyer la clé SSH
           rm -f ~/.ssh/sf_key
+
+  cleanup-tag:
+    name: Delete Git Tag on Failure
+    needs: [build-non-macos, build-macos]
+    if: failure() && (github.event_name == 'workflow_dispatch' || github.ref_type == 'tag' || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete Tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.inputs.target_tag || github.ref_name }}"
+          echo "Build failed. Deleting tag $TAG from repository..."
+          gh api -X DELETE "/repos/${{ github.repository }}/git/refs/tags/$TAG" || true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tutodecode
 description: "T2DECODE - Plateforme d'apprentissage locale"
 publish_to: 'none'
-version: 1.0.2+19
+version: 1.0.2+20
 environment:
   sdk: ">=2.18.0 <4.0.0"
 


### PR DESCRIPTION
Bumps version to 1.0.2+20 and adds a cleanup job to delete the Git tag if the build workflow fails.