### PR TITLE
chore(release): reset version to 1.0.2+19

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tutodecode
 description: "T2DECODE - Plateforme d'apprentissage locale"
 publish_to: 'none'
-version: 1.0.2+20
+version: 1.0.2+19
 environment:
   sdk: ">=2.18.0 <4.0.0"
 


### PR DESCRIPTION
Resets version metadata to 1.0.2+19 to cleanly trigger a fresh v1.0.2.1 release now that the failed tags v1.0.2.1, v1.0.2.2, and v1.0.2.3 have been deleted.