### PR TITLE
docs: update license references to GPL-3.0

### DIFF
--- a/landing_page/index.html
+++ b/landing_page/index.html
@@ -75,7 +75,7 @@
                 <div class="vision-card glass">
                     <div class="icon-box">🗝️</div>
                     <h3>Open Knowledge</h3>
-                    <p>Tout notre curriculum est public sur GitHub (AGPL-3.0). Vous pouvez l'auditer, le modifier et le fork.</p>
+                    <p>Tout notre curriculum est public sur GitHub (GPL-3.0). Vous pouvez l'auditer, le modifier et le fork.</p>
                 </div>
                 <div class="vision-card glass">
                     <div class="icon-box">🔋</div>
@@ -240,7 +240,7 @@
                         <span title="Dart">Dart</span>
                         <span title="Ollama">Ollama</span>
                         <span title="Linux">Linux</span>
-                        <span title="AGPL-3.0">AGPLv3</span>
+                        <span title="GPL-3.0">GPLv3</span>
                     </div>
                 </div>
             </div>
@@ -352,7 +352,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
-                <p>© 2026 Association TUTODECODE. Code sous licence AGPL-3.0.</p>
+                <p>© 2026 Association TUTODECODE. Code sous licence GPL-3.0.</p>
                 <p style="font-size: 0.75rem; opacity: 0.5; margin-top: 0.5rem;">Vivre l'informatique en toute liberté.</p>
             </div>
         </div>

--- a/lib/core/security/source_authentication.dart
+++ b/lib/core/security/source_authentication.dart
@@ -21,7 +21,7 @@ const Map<String, dynamic> officialDeveloper = {
   'website': 'https://www.tutodecode.org',
   'contact': 'contact@tutodecode.org',
   'github': 'https://github.com/TUTODECODE-FR/T2DECODE',
-  'license': 'AGPL-3.0',
+  'license': 'GPL-3.0',
   'developer_id': 'TUTODECODE_OFFICIAL_DEV_001',
 };
 


### PR DESCRIPTION
Met à jour toutes les références à la licence AGPL-3.0 vers GPL-3.0 dans les métadonnées de l'application et la landing page pour correspondre au fichier LICENSE.