### PR TITLE
fix: resolve CocoaPods CDN DNS resolution failures on macOS

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -335,15 +335,6 @@ jobs:
           # On workflow_dispatch, build the exact tag the user asked for (avoid uploading main builds to an older tag release).
           ref: ${{ env.TARGET_TAG }}
 
-      - name: Flush DNS cache
-        shell: bash
-        run: |
-          sudo networksetup -listallnetworkservices | grep -v '\*' | tail -n +2 | while read -r service; do
-            sudo networksetup -setdnsservers "$service" 8.8.8.8 8.8.4.4 || true
-          done
-          sudo dscacheutil -flushcache
-          sudo killall -HUP mDNSResponder || true
-
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295
         with:

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -74,15 +74,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Flush DNS cache
-        shell: bash
-        run: |
-          sudo networksetup -listallnetworkservices | grep -v '\*' | tail -n +2 | while read -r service; do
-            sudo networksetup -setdnsservers "$service" 8.8.8.8 8.8.4.4 || true
-          done
-          sudo dscacheutil -flushcache
-          sudo killall -HUP mDNSResponder || true
-
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295
         with:


### PR DESCRIPTION
Cette Pull Request corrige les échecs de résolution DNS sur les runners macOS en :
1. Remplaçant la source CDN instable de CocoaPods par le dépôt Git officiel de Specs sur GitHub.
2. Supprimant l'étape networksetup des workflows CI/CD qui écrasait les DNS internes de GitHub Actions par des DNS externes bloqués.