### PR TITLE
fix(build): change CocoaPods spec repo to CDN to prevent github.com DNS failures

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 platform :ios, '13.0'
 require 'fileutils'
 

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,5 +1,5 @@
 # Explicit source to avoid cdn.cocoapods.org DNS failures on CI runners
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.


### PR DESCRIPTION
This changes the podfile source to cdn.cocoapods.org to avoid 'Could not resolve host: github.com' timeouts during CI build.