### PR TITLE
ci: enable Swift Package Manager in Flutter config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: 'stable'
+
+      - name: Enable Swift Package Manager
+        run: flutter config --enable-swift-package-manager
       # The analysis requires to retrieve dependencies and build successfully
       - name: Build
         run: make get

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -84,6 +84,9 @@ jobs:
           channel: "stable"
           cache: true
 
+      - name: Enable Swift Package Manager
+        run: flutter config --enable-swift-package-manager
+
       - name: Get dependencies
         run: flutter pub get # NOSONAR
 
@@ -344,6 +347,9 @@ jobs:
           flutter-version: "3.41.4"
           channel: "stable"
           cache: true
+
+      - name: Enable Swift Package Manager
+        run: flutter config --enable-swift-package-manager
 
       - name: Get dependencies
         run: flutter pub get # NOSONAR

--- a/.github/workflows/mobsf.yml
+++ b/.github/workflows/mobsf.yml
@@ -34,6 +34,9 @@ jobs:
           flutter-version: "3.41.4"
           channel: "stable"
 
+      - name: Enable Swift Package Manager
+        run: flutter config --enable-swift-package-manager
+
       - name: Get dependencies
         run: flutter pub get # NOSONAR
 

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -42,6 +42,9 @@ jobs:
           channel: "stable"
           cache: true
 
+      - name: Enable Swift Package Manager
+        run: flutter config --enable-swift-package-manager
+
       - name: Get dependencies
         run: flutter pub get
 
@@ -82,6 +85,9 @@ jobs:
           flutter-version: "3.41.4"
           channel: "stable"
           cache: true
+
+      - name: Enable Swift Package Manager
+        run: flutter config --enable-swift-package-manager
 
       - name: Get dependencies
         run: flutter pub get


### PR DESCRIPTION
Fixes the macOS build by explicitly enabling Swift Package Manager in Flutter before building, preventing Flutter from automatically falling back to CocoaPods and failing on CDN DNS resolution.