### PR TITLE
ci: restore DNS flush to prevent macOS runner network hang

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -338,6 +338,16 @@ jobs:
           # On workflow_dispatch, build the exact tag the user asked for (avoid uploading main builds to an older tag release).
           ref: ${{ env.TARGET_TAG }}
 
+      - name: Flush DNS cache
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sudo networksetup -listallnetworkservices | grep -v '\*' | tail -n +2 | while read -r service; do
+            sudo networksetup -setdnsservers "$service" 8.8.8.8 8.8.4.4 || true
+          done
+          sudo dscacheutil -flushcache
+          sudo killall -HUP mDNSResponder || true
+
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295
         with:

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -78,6 +78,16 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Flush DNS cache
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sudo networksetup -listallnetworkservices | grep -v '\*' | tail -n +2 | while read -r service; do
+            sudo networksetup -setdnsservers "$service" 8.8.8.8 8.8.4.4 || true
+          done
+          sudo dscacheutil -flushcache
+          sudo killall -HUP mDNSResponder || true
+
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295
         with:


### PR DESCRIPTION
Restores the DNS flush step on macOS runners to prevent the runner from losing network connection and hanging for 1 hour when trying to resolve domains.