### PR TITLE
ci: revert SPM to fix macOS runner hang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           channel: 'stable'
 
-      - name: Enable Swift Package Manager
-        run: flutter config --enable-swift-package-manager
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
       # The analysis requires to retrieve dependencies and build successfully
       - name: Build
         run: make get

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -84,8 +84,8 @@ jobs:
           channel: "stable"
           cache: true
 
-      - name: Enable Swift Package Manager
-        run: flutter config --enable-swift-package-manager
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Get dependencies
         run: flutter pub get # NOSONAR
@@ -355,8 +355,8 @@ jobs:
           channel: "stable"
           cache: true
 
-      - name: Enable Swift Package Manager
-        run: flutter config --enable-swift-package-manager
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Get dependencies
         run: flutter pub get # NOSONAR

--- a/.github/workflows/mobsf.yml
+++ b/.github/workflows/mobsf.yml
@@ -34,8 +34,8 @@ jobs:
           flutter-version: "3.41.4"
           channel: "stable"
 
-      - name: Enable Swift Package Manager
-        run: flutter config --enable-swift-package-manager
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Get dependencies
         run: flutter pub get # NOSONAR

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -42,8 +42,8 @@ jobs:
           channel: "stable"
           cache: true
 
-      - name: Enable Swift Package Manager
-        run: flutter config --enable-swift-package-manager
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Get dependencies
         run: flutter pub get
@@ -95,8 +95,8 @@ jobs:
           channel: "stable"
           cache: true
 
-      - name: Enable Swift Package Manager
-        run: flutter config --enable-swift-package-manager
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Get dependencies
         run: flutter pub get


### PR DESCRIPTION
Disabling Swift Package Manager globally during the build because the GitHub Actions macOS 14 runner hangs indefinitely when xcodebuild tries to resolve dependencies via SPM on Flutter projects. By disabling SPM, Flutter will automatically fallback to CocoaPods (which is now completely stable since the DNS flush fix from the previous PR).