### PR TITLE
ci: bypass DNS for CocoaPods CDN via hosts file

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -338,11 +338,11 @@ jobs:
           # On workflow_dispatch, build the exact tag the user asked for (avoid uploading main builds to an older tag release).
           ref: ${{ env.TARGET_TAG }}
 
-      - name: Pre-resolve CocoaPods CDN
+      - name: Workaround CocoaPods CDN issue
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          for i in 1 2 3; do curl -s -I https://cdn.cocoapods.org && break || sleep 5; done
+          echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
 
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -78,11 +78,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Pre-resolve CocoaPods CDN
+      - name: Workaround CocoaPods CDN issue
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          for i in 1 2 3; do curl -s -I https://cdn.cocoapods.org && break || sleep 5; done
+          echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
 
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295


### PR DESCRIPTION
The previous pre-resolution curl check only masked the DNS issue on macOS runners without fixing the CocoaPods download. This PR introduces a definitive fix by manually adding the IPv4 address of the Cloudflare CDN to the runner's /etc/hosts file, bypassing the broken IPv6 routing entirely.