### PR TITLE
ci: force CocoaPods Specs Git repo directly in Podfile

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -342,7 +342,9 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
+          echo "source 'https://github.com/CocoaPods/Specs.git'" > temp_podfile
+          cat macos/Podfile >> temp_podfile
+          mv temp_podfile macos/Podfile
 
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -82,7 +82,9 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
+          echo "source 'https://github.com/CocoaPods/Specs.git'" > temp_podfile
+          cat macos/Podfile >> temp_podfile
+          mv temp_podfile macos/Podfile
 
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295


### PR DESCRIPTION
The jsdelivr CDN used by CocoaPods is failing to resolve. This definitively forces CocoaPods to use the Git specs repo by injecting the source directly into the macos/Podfile.