### PR TITLE
ci: use hosts file for both jsdelivr and cocoapods CDNs to prevent runner crash

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -342,9 +342,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          echo "source 'https://github.com/CocoaPods/Specs.git'" > temp_podfile
-          cat macos/Podfile >> temp_podfile
-          mv temp_podfile macos/Podfile
+          echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
+          echo "104.16.86.20 cdn.jsdelivr.net" | sudo tee -a /etc/hosts
 
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -82,9 +82,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          echo "source 'https://github.com/CocoaPods/Specs.git'" > temp_podfile
-          cat macos/Podfile >> temp_podfile
-          mv temp_podfile macos/Podfile
+          echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
+          echo "104.16.86.20 cdn.jsdelivr.net" | sudo tee -a /etc/hosts
 
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295


### PR DESCRIPTION
The previous fix of using the Git Specs repository was too heavy and caused the macos-latest runner to hang and crash after 49 minutes. This reverts to the hosts file workaround, but applies it to BOTH cdn.cocoapods.org and the redirect target cdn.jsdelivr.net, fixing the root cause of the network block without freezing the runner.