### PR TITLE
ci: fix macOS build hang caused by hdiutil and background dart processes

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -377,6 +377,9 @@ jobs:
         shell: bash
         run: |
           flutter build macos --release
+          killall dart || true
+          sync
+          sleep 2
 
           APP_PATH="build/macos/Build/Products/Release/T2DECODE.app"
 

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -32,6 +32,8 @@ ln -s /Applications "$DMG_STAGING_DIR/Applications"
 
 # 5. Créer le DMG
 echo "💿 Création de l'image disque (.dmg)..."
+sync
+sleep 2
 hdiutil create -volname "T2DECODE" -srcfolder "$DMG_STAGING_DIR" -ov -format UDZO "$BUILD_DIR/$DMG_NAME"
 
 echo "✅ DMG créé avec succès : $BUILD_DIR/$DMG_NAME"


### PR DESCRIPTION
The macOS build succeeds but the GitHub Actions step hangs indefinitely. This is a known issue on macos-latest caused by 1) the Dart daemon staying alive in the background and keeping stdout open, and 2) hdiutil create encountering file system locks. This PR explicitly kills background dart processes after the build, and adds sync/sleep before hdiutil.