### PR TITLE
ci: fix macOS build hang caused by ditto

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -395,7 +395,10 @@ jobs:
           cp -f T2DECODE-macOS-Installer.pkg T2DECODE-macOS.pkg
 
           # Zip
+          sync
+          sleep 2
           ditto -c -k --keepParent "$APP_PATH" T2DECODE-macOS.zip
+          echo "🏁 Fin de l'étape Build macOS app"
 
       - name: Sign and notarize macOS artifacts
         if: matrix.platform == 'macos' && env.MACOS_CERT_P12_BASE64 != '' && env.MACOS_CERT_PASSWORD != '' && env.MACOS_CERT_IDENTITY != '' && env.APPLE_ID != '' && env.APPLE_APP_SPECIFIC_PASSWORD != '' && env.APPLE_TEAM_ID != ''


### PR DESCRIPTION
The final Apple utility that interacts with the file system (ditto) is also hanging for the same reasons as hdiutil and pkgbuild. Applying sync and sleep.