### PR TITLE
ci: prevent DNS ENOTFOUND by safely appending to /etc/hosts

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -342,6 +342,7 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
+          echo "" | sudo tee -a /etc/hosts
           echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
           echo "104.16.86.20 cdn.jsdelivr.net" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -82,6 +82,7 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: |
+          echo "" | sudo tee -a /etc/hosts
           echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
           echo "104.16.86.20 cdn.jsdelivr.net" | sudo tee -a /etc/hosts
 


### PR DESCRIPTION
If /etc/hosts on the runner lacks a trailing newline, appending directly will corrupt the last entry (often localhost), breaking the mDNSResponder daemon and causing ENOTFOUND errors in subsequent actions like upload-artifact.