### PR TITLE
ci: remove destructive CocoaPods DNS workaround

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -338,14 +338,6 @@ jobs:
           # On workflow_dispatch, build the exact tag the user asked for (avoid uploading main builds to an older tag release).
           ref: ${{ env.TARGET_TAG }}
 
-      - name: Workaround CocoaPods CDN issue
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          echo "" | sudo tee -a /etc/hosts
-          echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
-          echo "104.16.86.20 cdn.jsdelivr.net" | sudo tee -a /etc/hosts
-
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295
         with:

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -78,14 +78,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Workaround CocoaPods CDN issue
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          echo "" | sudo tee -a /etc/hosts
-          echo "104.18.191.9 cdn.cocoapods.org" | sudo tee -a /etc/hosts
-          echo "104.16.86.20 cdn.jsdelivr.net" | sudo tee -a /etc/hosts
-
       - name: Setup Flutter
         uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295
         with:


### PR DESCRIPTION
Modifying /etc/hosts on macOS 14 runners permanently corrupts the mDNSResponder daemon, causing ENOTFOUND errors in subsequent actions like upload-artifact.