### PR TITLE
ci: fix CocoaPods cache poisoning

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -365,6 +365,10 @@ jobs:
           test -n "${{ env.APPLE_APP_SPECIFIC_PASSWORD }}"
           test -n "${{ env.APPLE_TEAM_ID }}"
 
+      - name: Clear corrupted CocoaPods cache
+        if: matrix.platform == 'macos'
+        run: rm -rf ~/.cocoapods/repos
+
       - name: Build macOS app (unsigned by default)
         if: matrix.platform == 'macos'
         shell: bash

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -94,6 +94,10 @@ jobs:
       - name: Run tests
         run: flutter test --dart-define=SKIP_GOLDENS=true
 
+      - name: Clear corrupted CocoaPods cache
+        if: matrix.platform == 'macos'
+        run: rm -rf ~/.cocoapods/repos
+
       - name: Compile macOS App (unsigned)
         if: matrix.platform == 'macos'
         run: flutter build macos --release


### PR DESCRIPTION
This PR clears the corrupted CocoaPods cache (`~/.cocoapods/repos`) before compiling the macOS app, to avoid the runner trying to `git clone` the CDN URL.