### PR TITLE
ci: final fix for CocoaPods DNS timeouts

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,6 @@
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
-source 'https://github.com/CocoaPods/Specs.git'
 
 project 'Runner', {
   'Debug' => :debug,

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -3,7 +3,6 @@ platform :osx, '10.15'
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
-source 'https://github.com/CocoaPods/Specs.git'
 
 project 'Runner', {
   'Debug' => :debug,


### PR DESCRIPTION
Removes the manually injected Git source for CocoaPods Specs that was still lingering in the Podfiles. Now CocoaPods will natively use the CDN with a clean cache.